### PR TITLE
Moved checkpointing inside training loop

### DIFF
--- a/ferminet/train.py
+++ b/ferminet/train.py
@@ -428,7 +428,7 @@ def train(cfg: ml_collections.ConfigDict):
         logging.info('Step %05d: %03.4f E_h, pmove=%0.2f', t, loss, pmove)
         writer.write(t, step=t, energy=loss._npy_value, pmove=pmove._npy_value)  # pylint: disable=protected-access
 
-    # Checkpointing
-    if time.time() - time_of_last_ckpt > cfg.log.save_frequency * 60:
-      checkpoint.save(ckpt_save_path, t, data, params, opt_state, mcmc_width)
-      time_of_last_ckpt = time.time()
+      # Checkpointing
+      if time.time() - time_of_last_ckpt > cfg.log.save_frequency * 60:
+        checkpoint.save(ckpt_save_path, t, data, params, opt_state, mcmc_width)
+        time_of_last_ckpt = time.time()


### PR DESCRIPTION
The indentation level of the checkpointing statement in train.train() is one too low, causing it to only execute once after all cfg.optim.iterations steps.