### PR TITLE
Fix KFAC error in presence of empty spin channels

### DIFF
--- a/ferminet/networks.py
+++ b/ferminet/networks.py
@@ -115,7 +115,7 @@ def init_fermi_net_params(
       'single': [{} for i in range(len(hidden_dims))],
       'double': [{} for i in range(len_double)],
       'orbital': [],
-      'envelope': [{} for spin in spins]
+      'envelope': [{} for spin in spins if spin > 0]
   }
 
   if envelope_type in ['output', 'exact_cusp']:
@@ -165,8 +165,8 @@ def init_fermi_net_params(
             params['envelope'] = {'pi': pi, 'sigma': sigma}
             j += 1
   else:
-    params['envelope'] = [{} for spin in spins]
-    for i, spin in enumerate(spins):
+    params['envelope'] = [{} for spin in spins if spin > 0]
+    for i, spin in enumerate((spin for spin in spins if spin > 0)):
       nparam = sum(spins)*determinants if full_det else spin*determinants
       params['envelope'][i]['pi'] = jnp.ones((natom, nparam))
       if envelope_type == 'isotropic':
@@ -223,7 +223,7 @@ def init_fermi_net_params(
           raise NotImplementedError('HF Initialization not implemented for '
                                     '%s orbitals' % orb[1])
 
-  for i, spin in enumerate(spins):
+  for i, spin in enumerate((spin for spin in spins if spin > 0)):
     nparam = sum(spins)*determinants if full_det else spin*determinants
     key, subkey = jax.random.split(key)
     params['orbital'].append({})


### PR DESCRIPTION
When defining a system with empty spin channels, e.g. hydrogen,

```
cfg.system.electrons = (1, 0)
cfg.system.molecule = [system.Atom('H', (0, 0, 0))]
```

KFAC errors due to the presence of empty parameter dicts in the params pytree:

```
Traceback (most recent call last):

  File "qmc.py", line 11, in <module>
    train.train(cfg)
  File "/home/ferminet/deepmind/ferminet/ferminet/train.py", line 488, in train
    params, opt_state, stats = optimizer.step(  # pytype: disable=attribute-error
  File "/home/ferminet/venv/deepmind/lib/python3.8/site-packages/kfac_ferminet_alpha/optimizer.py", line 566, in step
    return self._jit_step(params, state, rng, batch, func_state, batch_size,
  File "/home/ferminet/venv/deepmind/lib/python3.8/site-packages/kfac_ferminet_alpha/optimizer.py", line 442, in _step
    vectors = self.propose_directions(
  File "/home/ferminet/venv/deepmind/lib/python3.8/site-packages/kfac_ferminet_alpha/optimizer.py", line 578, in propose_directions
    preconditioned_grads = self.estimator.multiply_matpower(grads, -1)
  File "/home/ferminet/venv/deepmind/lib/python3.8/site-packages/kfac_ferminet_alpha/estimator.py", line 234, in multiply_matpower
    return self.vec_block_apply(func, parameter_structured_vector)
  File "/home/ferminet/venv/deepmind/lib/python3.8/site-packages/kfac_ferminet_alpha/estimator.py", line 181, in vec_block_apply
    per_block_vectors = self.vectors_to_blocks(parameter_structured_vector)
  File "/home/ferminet/venv/deepmind/lib/python3.8/site-packages/kfac_ferminet_alpha/estimator.py", line 134, in vectors_to_blocks
    per_block_vectors.append(tuple(params_dict.pop(v) for v in block_vars))
  File "/home/ferminet/venv/deepmind/lib/python3.8/site-packages/kfac_ferminet_alpha/estimator.py", line 134, in <genexpr>
    per_block_vectors.append(tuple(params_dict.pop(v) for v in block_vars))
KeyError: br
```

This is fixed by adding conditionals to the generator expressions for the parameter dicts which ignore empty spin channels.