### PR TITLE
Froze version of h5py dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ REQUIRED_PACKAGES = [
     'absl-py',
     'attrs',
     'chex',
+    'h5py==2.10.0',
     'jax',
     'jaxlib',
     'kfac_ferminet_alpha @ git+https://github.com/deepmind/deepmind_research#egg=kfac_ferminet_alpha&subdirectory=kfac_ferminet_alpha',  # pylint: disable=line-too-long

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ REQUIRED_PACKAGES = [
     'absl-py',
     'attrs',
     'chex',
+    # TODO(g.cassella20@imperial.ac.uk): Remove this restriction once PySCF 2.0 is on PyPI
     'h5py==2.10.0',
     'jax',
     'jaxlib',

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,8 @@ REQUIRED_PACKAGES = [
     'absl-py',
     'attrs',
     'chex',
-    # TODO(g.cassella20@imperial.ac.uk): Remove this restriction once PySCF 2.0 is on PyPI
+    # TODO(g.cassella20@imperial.ac.uk): Remove this restriction once PySCF 2.0
+    # is on PyPI
     'h5py==2.10.0',
     'jax',
     'jaxlib',


### PR DESCRIPTION
Fixes error from PySCF dependency. Ideally this would be fixed on PySCF's end but this works for now.