### PR TITLE
Fix code comment errors in the Jax implementation.

### DIFF
--- a/ferminet/networks.py
+++ b/ferminet/networks.py
@@ -308,7 +308,7 @@ def construct_symmetric_features(h_one: jnp.ndarray, h_two: jnp.ndarray,
     one-electron features, the mean of the one-electron features over each
     (occupied) spin channel, and the mean of the two-electron features over each
     (occupied) spin channel. Output shape (nelectrons, 3*n1 + 2*n2) if there are
-    both spin-up and spin-down electrons and (nelectrons, 2*n1, n2) otherwise.
+    both spin-up and spin-down electrons and (nelectrons, 2*n1 + n2) otherwise.
   """
   # Split features into spin up and spin down electrons
   spin_partitions = _partition_spins(spins)

--- a/ferminet/train.py
+++ b/ferminet/train.py
@@ -55,7 +55,7 @@ def init_electrons(
       devices.
 
   Returns:
-    array of (batch_size, nalpha*nbeta*ndim) of initial (random) electron
+    array of (batch_size, (nalpha+nbeta)*ndim) of initial (random) electron
     positions in the initial MCMC configurations and ndim is the dimensionality
     of the space (i.e. typically 3).
   """


### PR DESCRIPTION
For better readability, we'd better correct output shapes of these functions:
- `ferminet.networks.construct_symmetric_features`
- `ferminet.train.init_electrons`