### PR TITLE
Adding WQMC objective option

### DIFF
--- a/ferminet/base_config.py
+++ b/ferminet/base_config.py
@@ -53,6 +53,7 @@ def default() -> ml_collections.ConfigDict:
       # importlib.import_module.
       'config_module': __name__,
       'optim': {
+          'objective': 'vmc', # objective type. Either 'vmc' or 'wvmc'
           'iterations': 1000000,  # number of iterations
           'optimizer': 'kfac',  # one of adam, kfac, lamb, none
           'lr': {

--- a/ferminet/base_config.py
+++ b/ferminet/base_config.py
@@ -53,7 +53,7 @@ def default() -> ml_collections.ConfigDict:
       # importlib.import_module.
       'config_module': __name__,
       'optim': {
-          'objective': 'vmc', # objective type. Either 'vmc' or 'wvmc'
+          'objective': 'vmc', # objective type. Either 'vmc' or 'wqmc'
           'iterations': 1000000,  # number of iterations
           'optimizer': 'kfac',  # one of adam, kfac, lamb, none
           'lr': {

--- a/ferminet/configs/atom_test.py
+++ b/ferminet/configs/atom_test.py
@@ -73,6 +73,9 @@ def get_config():
     cfg.system.set_molecule = _adjust_nuclear_charge
     cfg.config_module = '.atom'
   cfg.network.network_type = 'psiformer'
-  cfg.optim.iterations = 10000
-  cfg.optim.objective = 'vmc'
+  cfg.optim.iterations = 10_000
+  cfg.optim.lr.delay = 5_000
+  cfg.optim.clip_median = True
+  cfg.debug.deterministic = True
+  cfg.optim.kfac.norm_constraint = 1e-3
   return cfg

--- a/ferminet/configs/atom_test.py
+++ b/ferminet/configs/atom_test.py
@@ -1,0 +1,78 @@
+# Copyright 2020 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Generic single-atom configuration for FermiNet."""
+
+from ferminet import base_config
+from ferminet.utils import elements
+from ferminet.utils import system
+import ml_collections
+
+
+def _adjust_nuclear_charge(cfg):
+  """Sets the molecule, nuclear charge electrons for the atom.
+
+  Note: function name predates this logic but is kept for compatibility with
+  xm_expt.py.
+
+  Args:
+    cfg: ml_collections.ConfigDict after all argument parsing.
+
+  Returns:
+    ml_collections.ConfictDict with the nuclear charge for the atom in
+    cfg.system.molecule and cfg.system.charge appropriately set.
+  """
+  if cfg.system.molecule:
+    atom = cfg.system.molecule[0]
+  else:
+    atom = system.Atom(symbol=cfg.system.atom, coords=(0, 0, 0))
+
+  if abs(cfg.system.delta_charge) > 1.e-8:
+    nuclear_charge = atom.charge + cfg.system.delta_charge
+    cfg.system.molecule = [
+        system.Atom(atom.symbol, atom.coords, nuclear_charge)
+    ]
+  else:
+    cfg.system.molecule = [atom]
+
+  if not cfg.system.electrons:
+    atomic_number = elements.SYMBOLS[atom.symbol].atomic_number
+    if 'charge' in cfg.system:
+      atomic_number -= cfg.system.charge
+    if ('spin_polarisation' in cfg.system
+        and cfg.system.spin_polarisation is not None):
+      spin_polarisation = cfg.system.spin_polarisation
+    else:
+      spin_polarisation = elements.ATOMIC_NUMS[atomic_number].spin_config
+    nalpha = (atomic_number + spin_polarisation) // 2
+    cfg.system.electrons = (nalpha, atomic_number - nalpha)
+
+  return cfg
+
+
+def get_config():
+  """Returns config for running generic atoms with qmc."""
+  cfg = base_config.default()
+  cfg.system.atom = ''
+  cfg.system.charge = 0
+  cfg.system.delta_charge = 0.0
+  cfg.system.spin_polarisation = ml_collections.FieldReference(
+      None, field_type=int)
+  with cfg.ignore_type():
+    cfg.system.set_molecule = _adjust_nuclear_charge
+    cfg.config_module = '.atom'
+  cfg.network.network_type = 'psiformer'
+  cfg.optim.iterations = 10000
+  cfg.optim.objective = 'vmc'
+  return cfg

--- a/ferminet/configs/li_wqmc.py
+++ b/ferminet/configs/li_wqmc.py
@@ -64,7 +64,7 @@ def _adjust_nuclear_charge(cfg):
 def get_config():
   """Returns config for running generic atoms with qmc."""
   cfg = base_config.default()
-  cfg.system.atom = ''
+  cfg.system.atom = 'Li'
   cfg.system.charge = 0
   cfg.system.delta_charge = 0.0
   cfg.system.spin_polarisation = ml_collections.FieldReference(
@@ -78,4 +78,5 @@ def get_config():
   cfg.optim.clip_median = True
   cfg.debug.deterministic = True
   cfg.optim.kfac.norm_constraint = 1e-3
+  cfg.optim.objective = 'wqmc'
   return cfg

--- a/ferminet/hamiltonian.py
+++ b/ferminet/hamiltonian.py
@@ -174,25 +174,25 @@ def potential_nuclear_nuclear(charges: Array, atoms: Array) -> jnp.ndarray:
     charges: Shape (natoms). Nuclear charges of the atoms.
     atoms: Shape (natoms, ndim). Positions of the atoms.
   """
-  natoms = atoms.shape[0]
-  r_aa = jnp.sqrt(jnp.sum((atoms[None, ...] - atoms[:, None] + 
-      jnp.eye(natoms)[..., None])**2, axis=-1))
+  r_aa = jnp.linalg.norm(atoms[None, ...] - atoms[:, None], axis=-1)
   return jnp.sum(
       jnp.triu((charges[None, ...] * charges[..., None]) / r_aa, k=1))
 
 
-def potential_energy(r_ae: Array, pos: Array, atoms: Array,
+def potential_energy(r_ae: Array, r_ee: Array, atoms: Array,
                      charges: Array) -> jnp.ndarray:
   """Returns the potential energy for this electron configuration.
 
   Args:
     r_ae: Shape (nelectrons, natoms). r_ae[i, j] gives the distance between
       electron i and atom j.
-    pos: Shape (neletrons, ndim). Electron positions.
+    r_ee: Shape (neletrons, nelectrons, :). r_ee[i,j,0] gives the distance
+      between electrons i and j. Other elements in the final axes are not
+      required.
     atoms: Shape (natoms, ndim). Positions of the atoms.
     charges: Shape (natoms). Nuclear charges of the atoms.
   """
-  return (potential_electron_electron(pos) +
+  return (potential_electron_electron(r_ee) +
           potential_electron_nuclear(charges, r_ae) +
           potential_nuclear_nuclear(charges, atoms))
 

--- a/ferminet/loss.py
+++ b/ferminet/loss.py
@@ -258,13 +258,13 @@ def make_loss(network: networks.LogFermiNetLike,
   return total_energy
 
 
-def make_wvmc_loss(network: networks.LogFermiNetLike,
+def make_wqmc_loss(network: networks.LogFermiNetLike,
                    local_energy: hamiltonian.LocalEnergy,
                    clip_local_energy: float = 0.0,
                    clip_from_median: bool = True,
                    center_at_clipped_energy: bool = True,
                    complex_output: bool = False) -> LossFn:
-  """Creates the loss function, including custom gradients.
+  """Creates the WQMC loss function, including custom gradients.
 
   Args:
     network: callable which evaluates the log of the magnitude of the
@@ -362,7 +362,7 @@ def make_wvmc_loss(network: networks.LogFermiNetLike,
       return out.sum()
 
     score = jax.grad(log_q, argnums=1)
-    primals = (primals[0], data.positions, data.spins, data.atoms, data.charges)
+    primals = (params, data.positions, data.spins, data.atoms, data.charges)
     tangents = (
         tangents[0],
         tangents[2].positions,

--- a/ferminet/loss.py
+++ b/ferminet/loss.py
@@ -38,6 +38,7 @@ class AuxiliaryLossData:
   variance: jax.Array
   local_energy: jax.Array
   clipped_energy: jax.Array
+  grad_local_energy: jax.Array
 
 
 class LossFn(Protocol):
@@ -202,8 +203,8 @@ def make_loss(network: networks.LogFermiNetLike,
     loss = constants.pmean(jnp.mean(e_l))
     loss_diff = e_l - loss
     variance = constants.pmean(jnp.mean(loss_diff * jnp.conj(loss_diff)))
-    return loss, AuxiliaryLossData(
-        variance=variance.real, local_energy=e_l, clipped_energy=e_l)
+    return loss, AuxiliaryLossData(variance=variance.real, local_energy=e_l, 
+        clipped_energy=e_l, grad_local_energy=None)
 
   @total_energy.defjvp
   def total_energy_jvp(primals, tangents):  # pylint: disable=unused-variable
@@ -252,6 +253,138 @@ def make_loss(network: networks.LogFermiNetLike,
       primals_out = loss, aux_data
       device_batch_size = jnp.shape(aux_data.local_energy)[0]
       tangents_out = (jnp.dot(psi_tangent, diff) / device_batch_size, aux_data)
+    return primals_out, tangents_out
+
+  return total_energy
+
+
+def make_wmc_loss(network: networks.LogFermiNetLike,
+                  local_energy: hamiltonian.LocalEnergy,
+                  clip_local_energy: float = 0.0,
+                  clip_from_median: bool = True,
+                  center_at_clipped_energy: bool = True,
+                  complex_output: bool = False) -> LossFn:
+  """Creates the loss function, including custom gradients.
+
+  Args:
+    network: callable which evaluates the log of the magnitude of the
+      wavefunction (square root of the log probability distribution) at a
+      single MCMC configuration given the network parameters.
+    local_energy: callable which evaluates the local energy.
+    clip_local_energy: If greater than zero, clip local energies that are
+      outside [E_L - n D, E_L + n D], where E_L is the mean local energy, n is
+      this value and D the mean absolute deviation of the local energies from
+      the mean, to the boundaries. The clipped local energies are only used to
+      evaluate gradients.
+    clip_from_median: If true, center the clipping window at the median rather
+      than the mean. Potentially expensive in multi-host training, but more
+      accurate.
+    center_at_clipped_energy: If true, center the local energy differences
+      passed back to the gradient around the clipped local energy, so the mean
+      difference across the batch is guaranteed to be zero.
+    complex_output: If true, the local energies will be complex valued.
+
+  Returns:
+    Callable with signature (params, data) and returns (loss, aux_data), where
+    loss is the mean energy, and aux_data is an AuxiliaryLossDataobject. The
+    loss is averaged over the batch and over all devices inside a pmap.
+  """
+  batch_local_energy = jax.vmap(
+      local_energy,
+      in_axes=(
+          None,
+          0,
+          networks.FermiNetData(positions=0, spins=0, atoms=0, charges=0),
+      ),
+      out_axes=0,
+  )
+  batch_network = jax.vmap(network, in_axes=(None, 0, 0, 0, 0), out_axes=0)
+
+  @jax.custom_jvp
+  def total_energy(
+      params: networks.ParamTree,
+      key: chex.PRNGKey,
+      data: networks.FermiNetData,
+  ) -> Tuple[jnp.ndarray, AuxiliaryLossData]:
+    """Evaluates the total energy of the network for a batch of configurations.
+
+    Note: the signature of this function is fixed to match that expected by
+    kfac_jax.optimizer.Optimizer with value_func_has_rng=True and
+    value_func_has_aux=True.
+
+    Args:
+      params: parameters to pass to the network.
+      key: PRNG state.
+      data: Batched MCMC configurations to pass to the local energy function.
+
+    Returns:
+      (loss, aux_data), where loss is the mean energy, and aux_data is an
+      AuxiliaryLossData object containing the variance of the energy and the
+      local energy per MCMC configuration. The loss and variance are averaged
+      over the batch and over all devices inside a pmap.
+    """
+    keys = jax.random.split(key, num=data.positions.shape[0])
+    e_l = batch_local_energy(params, keys, data)
+    loss = constants.pmean(jnp.mean(e_l))
+    loss_diff = e_l - loss
+    variance = constants.pmean(jnp.mean(loss_diff * jnp.conj(loss_diff)))
+
+    def batch_local_energy_pos(pos):
+      network_data = networks.FermiNetData(positions=pos, spins=data.spins, 
+          atoms=data.atoms, charges=data.charges)
+      return batch_local_energy(params, keys, network_data).sum()
+    
+    grad_e_l = jax.grad(batch_local_energy_pos)(data.positions)
+    grad_e_l = jnp.tanh(jax.lax.stop_gradient(grad_e_l))
+    return loss, AuxiliaryLossData(variance=variance.real, local_energy=e_l, 
+        clipped_energy=e_l, grad_local_energy=grad_e_l)
+
+  @total_energy.defjvp
+  def total_energy_jvp(primals, tangents):  # pylint: disable=unused-variable
+    """Custom Jacobian-vector product for unbiased local energy gradients."""
+    params, key, data = primals
+    loss, aux_data = total_energy(params, key, data)
+
+    if clip_local_energy > 0.0:
+      aux_data.clipped_energy, diff = clip_local_values(
+          aux_data.local_energy,
+          loss,
+          clip_local_energy,
+          clip_from_median,
+          center_at_clipped_energy,
+          complex_output)
+    else:
+      diff = aux_data.local_energy - loss
+
+    def log_q(_p, _x):
+      out = batch_network(_p, _x, data.spins, data.atoms, data.charges)
+      kfac_jax.register_normal_predictive_distribution(out[:,None])
+      return out.sum()
+
+    score = jax.grad(log_q, argnums=1)
+    primals = (primals[0], primals[2].positions)
+    tangents = (tangents[0], tangents[2].positions)
+    score_primal, score_tangent = jax.jvp(score, primals, tangents)
+    
+    score_norm = (score_primal**2).sum(1, keepdims=True)
+    median = jnp.median(constants.all_gather(score_norm))
+    deviation = jnp.mean(jnp.abs(score_norm - median))
+    mask = score_norm < (median + 5*deviation)
+    log_q_tangent_out = (aux_data.grad_local_energy*score_tangent*mask).sum(1)
+    log_q_tangent_out *= (len(mask)/mask.sum())
+
+    primals = (primals[0], data.positions, data.spins, data.atoms, data.charges)
+    tangents = (
+        tangents[0],
+        tangents[2].positions,
+        tangents[2].spins,
+        tangents[2].atoms,
+        tangents[2].charges,
+    )
+    psi_primal, psi_tangent = jax.jvp(batch_network, primals, tangents)
+    log_q_tangent_out = diff*psi_tangent
+    primals_out = loss, aux_data
+    tangents_out = (log_q_tangent_out.mean(), aux_data)
     return primals_out, tangents_out
 
   return total_energy

--- a/ferminet/networks.py
+++ b/ferminet/networks.py
@@ -471,9 +471,8 @@ def construct_input_features(
   r_ae = jnp.linalg.norm(ae, axis=2, keepdims=True)
   # Avoid computing the norm of zero, as is has undefined grad
   n = ee.shape[0]
-  # r_ee = (
-  #     jnp.linalg.norm(ee + jnp.eye(n)[..., None], axis=-1) * (1.0 - jnp.eye(n)))
-  r_ee = jnp.sqrt(((ee + jnp.eye(n)[..., None])**2).sum(2)) * (1.0 - jnp.eye(n))
+  r_ee = (
+      jnp.linalg.norm(ee + jnp.eye(n)[..., None], axis=-1) * (1.0 - jnp.eye(n)))
   return ae, ee, r_ae, r_ee[..., None]
 
 

--- a/ferminet/networks.py
+++ b/ferminet/networks.py
@@ -471,9 +471,9 @@ def construct_input_features(
   r_ae = jnp.linalg.norm(ae, axis=2, keepdims=True)
   # Avoid computing the norm of zero, as is has undefined grad
   n = ee.shape[0]
-  r_ee = (
-      jnp.linalg.norm(ee + jnp.eye(n)[..., None], axis=-1) * (1.0 - jnp.eye(n)))
-
+  # r_ee = (
+  #     jnp.linalg.norm(ee + jnp.eye(n)[..., None], axis=-1) * (1.0 - jnp.eye(n)))
+  r_ee = jnp.sqrt(((ee + jnp.eye(n)[..., None])**2).sum(2)) * (1.0 - jnp.eye(n))
   return ae, ee, r_ae, r_ee[..., None]
 
 

--- a/ferminet/train.py
+++ b/ferminet/train.py
@@ -581,7 +581,7 @@ def train(cfg: ml_collections.ConfigDict, writer_manager=None):
         complex_output=cfg.network.get('complex', False)
     )
   elif cfg.optim.objective == 'wvmc':
-    evaluate_loss = qmc_loss_functions.make_wmc_loss(
+    evaluate_loss = qmc_loss_functions.make_wvmc_loss(
         log_network if cfg.network.get('complex', False) else logabs_network,
         local_energy,
         clip_local_energy=cfg.optim.clip_local_energy,

--- a/ferminet/train.py
+++ b/ferminet/train.py
@@ -580,8 +580,8 @@ def train(cfg: ml_collections.ConfigDict, writer_manager=None):
         center_at_clipped_energy=cfg.optim.center_at_clip,
         complex_output=cfg.network.get('complex', False)
     )
-  elif cfg.optim.objective == 'wvmc':
-    evaluate_loss = qmc_loss_functions.make_wvmc_loss(
+  elif cfg.optim.objective == 'wqmc':
+    evaluate_loss = qmc_loss_functions.make_wqmc_loss(
         log_network if cfg.network.get('complex', False) else logabs_network,
         local_energy,
         clip_local_energy=cfg.optim.clip_local_energy,


### PR DESCRIPTION
Hi everyone,

@dpfau asked me to create a PR implementing our recent work [Wasserstein Quantum Monte Carlo](https://arxiv.org/abs/2307.07050). I just finished the initial implementation and tested it for Li atom. 

Results for Li atom. The left plot demonstrates the relative energy error, where the ground true energy is taken from the [psiformer paper](https://arxiv.org/abs/2211.13672). The right plot demonstrates the variance of the local energy, which indicates the convergence to the ground energy eigenstate. All the values are smoothed with the running average over 100 iterations.
![image](https://github.com/deepmind/ferminet/assets/13628364/98b0ec3c-9b05-4971-8b06-6e577c325627)

The commands to run the test.
`ferminet --config ferminet/configs/atom_test.py --config.system.atom Li --config.batch_size 256 --config.pretrain.iterations 100 --config.optim.objective wvmc`
`ferminet --config ferminet/configs/atom_test.py --config.system.atom Li --config.batch_size 256 --config.pretrain.iterations 100 --config.optim.objective vmc`

**Nota Bene:**
- I had to change the evaluation of the potential to avoid 'nans' during backpropagation. It should be equivalent, but please review it.
- I guess I didn't completely follow your style guide, even though I was trying to stick to it where I could infer it.
- I haven't yet tested this particular implementation for bigger molecules (the ones we considered in the paper). Moreover, for some hyperparameters, I observed this implementation diverging for Li, perhaps, due to the smaller batch size compared to what we used in the paper.

Please, let me know how to proceed from here, and what to improve, test, and include.